### PR TITLE
Allow passing dicts to `localize_files`

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -134,10 +134,10 @@ following line to your ``jupyterhub_config.py``:
 .. code-block:: python
 
     # The principal JupyterHub is running as
-    c.YarnSpawner.principal = "jupyterhub"
+    c.YarnSpawner.principal = 'jupyterhub'
 
     # Path to the keytab you created
-    c.YarnSpawner.keytab = "/path/to/jupyterhub.keytab"
+    c.YarnSpawner.keytab = '/path/to/jupyterhub.keytab'
 
 
 Specifying Python Environments
@@ -285,15 +285,20 @@ either tool.
 
 .. code-block:: python
 
-    import skein
     c.YarnSpawner.localize_files = {
-        'environment': skein.File(
-            source='hdfs:///path/to/environments/environment.tar.gz',
-            type='archive',
-            visibility='public'
-        )
+        'environment': {
+            'source': 'hdfs:///path/to/environments/environment.tar.gz',
+            'visibility': 'public'
+        }
     }
     c.YarnSpawner.prologue = 'source environment/bin/activate'
+
+
+Note that we set ``visibility`` to ``public`` for the environment, so that
+multiple users can all share the same localized environment (reducing the cost
+of moving the environments around).
+
+For more information, see the `Skein documentation on distributing files`_.
 
 
 Additional Configuration Options
@@ -338,13 +343,11 @@ In summary, an example ``jupyterhub_config.py`` configuration enabling
     c.YarnSpawner.queue = 'jupyterhub'
 
     # Specify location of the archived Python environment
-    import skein
     c.YarnSpawner.localize_files = {
-        'environment': skein.File(
-            source='hdfs:///etc/jupyter/datascience.tar.gz',
-            type='archive',
-            visibility='public'
-        )
+        'environment': {
+            'source': 'hdfs:///path/to/environments/environment.tar.gz',
+            'visibility': 'public'
+        }
     }
     c.YarnSpawner.prologue = 'source environment/bin/activate'
 
@@ -388,6 +391,7 @@ other libraries:
 .. _venv-pack documentation:
 .. _venv-pack: https://jcrist.github.io/venv-pack/
 .. _YARN resource localization: https://hortonworks.com/blog/resource-localization-in-yarn-deep-dive/
+.. _Skein documentation on distributing files: https://jcrist.github.io/skein/distributing-files.html
 .. _jupyter-hdfscm: https://jcrist.github.io/hdfscm/
 .. _pyarrow: https://arrow.apache.org/docs/python/
 .. _skein: https://jcrist.github.io/skein/

--- a/yarnspawner/tests/test_spawner.py
+++ b/yarnspawner/tests/test_spawner.py
@@ -73,7 +73,11 @@ def test_specification():
     spawner.epilogue = 'Do this after'
     spawner.mem_limit = '1 G'
     spawner.cpu_limit = 2
-    spawner.localize_files = {'environment': 'environment.tar.gz'}
+    spawner.localize_files = {
+        'environment': 'environment.tar.gz',
+        'file2': {'source': 'path/to/file',
+                  'visibility': 'public'}
+    }
     spawner.env = {'TEST_ENV_VAR': 'TEST_VALUE'}
 
     spec = spawner._build_specification()
@@ -88,6 +92,8 @@ def test_specification():
     assert spec.master.resources == skein.Resources(memory='1 GiB', vcores=2)
 
     assert 'environment' in spec.master.files
+    assert 'file2' in spec.master.files
+    assert spec.master.files['file2'].visibility == 'public'
 
     assert 'TEST_ENV_VAR' in spec.master.env
     assert 'JUPYTERHUB_API_TOKEN' in spec.master.env


### PR DESCRIPTION
Allows for finer control without the user having to import ``skein``
directly.