### PR TITLE
Fix test fixtures for new JupyterHub

### DIFF
--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 set -xe
 
-conda install -c conda-forge jupyterhub notebook -y
+conda install -c conda-forge jupyterhub jupyterlab notebook -y
 
-pip install skein pytest pytest-tornado flake8 conda-pack
+pip install skein pytest pytest-asyncio flake8 conda-pack
 
 cd ~/yarnspawner
 pip install -v --no-deps .


### PR DESCRIPTION
The new release of JupyterHub broke our test fixtures (but not our
actual functionality). Update the tests to pass again.